### PR TITLE
ci: Update Dependabot config to assign dependency updates as `feat`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,26 +2,27 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     open-pull-requests-limit: 10
     schedule:
-      interval: "weekly"
-      time: "00:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      interval: 'weekly'
+      time: '00:00'
+      day: 'sunday'
+      timezone: 'America/Los_Angeles'
     commit-message:
-      prefix: "ci"
-      include: "scope"
+      prefix: 'ci'
+      include: 'scope'
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     open-pull-requests-limit: 10
     schedule:
-      interval: "weekly"
-      time: "00:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      interval: 'weekly'
+      time: '00:00'
+      day: 'sunday'
+      timezone: 'America/Los_Angeles'
     commit-message:
-      prefix: "build"
-      include: "scope"
+      prefix: 'feat'
+      prefix-development: 'build'
+      include: 'scope'


### PR DESCRIPTION
It seems like we can switch dependency updates to `feat` while maintaining development dependencies as `build.`

Let's give it a go and see how it works out.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#prefix-development